### PR TITLE
Fixed dark mode persistence between pages

### DIFF
--- a/gatsby-browser.js
+++ b/gatsby-browser.js
@@ -1,0 +1,7 @@
+import React from "react"
+
+import { DarkThemeProvider } from './src/pages/components/DarkThemeContext/DarkThemeContext'
+
+export const wrapRootElement = ({ element }) => {
+  return <DarkThemeProvider>{element}</DarkThemeProvider>
+}

--- a/src/pages/components/DarkThemeContext/DarkThemeContext.js
+++ b/src/pages/components/DarkThemeContext/DarkThemeContext.js
@@ -1,8 +1,25 @@
-import React from "react";
+import React, { useState, useContext } from "react"
 
 const DarkThemeContext = React.createContext({
-    darkMode: false,
-    setDarkMode:() => {},
-});
+  darkMode: false,
+  setDarkMode: () => {},
+})
 
-export default DarkThemeContext
+export const DarkThemeProvider = ({ children }) => {
+  const [isDark, setIsDark] = useState(false)
+
+  return (
+    <DarkThemeContext.Provider
+      value={{
+        darkMode: isDark,
+        setDarkMode: setIsDark,
+      }}
+    >
+      {children}
+    </DarkThemeContext.Provider>
+  )
+}
+
+const useDarkThemeContext = () => useContext(DarkThemeContext);
+
+export default useDarkThemeContext;

--- a/src/pages/components/DarkThemeSwitcher/DarkThemeSwitcher.js
+++ b/src/pages/components/DarkThemeSwitcher/DarkThemeSwitcher.js
@@ -1,74 +1,51 @@
-import React, { useContext } from 'react';
-import { IconButton, Tooltip } from '@material-ui/core';
-import { makeStyles, useTheme } from '@material-ui/core/styles';
-import LightThemeIcon from '@material-ui/icons/Brightness7';
-import DarkThemeIcon from '@material-ui/icons/Brightness4';
+import React from "react"
+import { IconButton, Tooltip } from "@material-ui/core"
+import { makeStyles, useTheme } from "@material-ui/core/styles"
+import LightThemeIcon from "@material-ui/icons/Brightness7"
+import DarkThemeIcon from "@material-ui/icons/Brightness4"
+import useDarkThemeContext from "../DarkThemeContext/DarkThemeContext"
 
-import DarkThemeContext from '../DarkThemeContext/DarkThemeContext';
+const useStyles = makeStyles(theme => ({
+  darkThemeButton: {
+    background: "none",
+    border: "none",
+  },
+  darkThemeMobileButton: {
+    [theme.breakpoints.up("sm")]: {
+      display: "none",
+    },
+    [theme.breakpoints.down("sm")]: {
+      background: "none",
+      border: "none",
+      display: "visible",
+      paddingLeft: theme.spacing(2),
+      minWidth: "25%",
+    },
+  },
+  menuHeaderText: {
+    minWidth: "97%",
+  },
+}))
 
 const DarkThemeSwitcher = ({ mobile }) => {
-    const useStyles = makeStyles((theme) => ({
-        darkThemeButton: {
-            background: "none",
-            border: "none",
-        },
-        darkThemeMobileButton: {
-            [theme.breakpoints.up('sm')]: {
-                display: "none",
-            },
-            [theme.breakpoints.down('sm')]: {
-                background: "none",
-                border: "none",
-                display: "visible",
-                paddingLeft: theme.spacing(2),
-                minWidth: '25%'
+  const classes = useStyles()
+  const { darkMode, setDarkMode } = useDarkThemeContext();
 
-            },
-        },
-        menuHeaderText: {
-            minWidth: '97%',
-        }
-    }));
+  const handleLightThemeToggle = () => {
+    setDarkMode(darkMode => !darkMode)
+  }
 
-
-
-    const classes = useStyles();
-    const { darkMode, setDarkMode } = useContext(DarkThemeContext);
-
-    const handleLightThemeToggle = () => {
-        setDarkMode(darkMode => !darkMode);
-        console.log("dark mode is ", darkMode)
-    };
-    console.log("React.useContext(DarkThemeContext).darkMode ", React.useContext(DarkThemeContext).darkMode)
-
-    return (
-        mobile ?
-        darkMode ?
-            <Tooltip title="Light Mode" className={classes.darkThemeMobileButton} onClick={handleLightThemeToggle} >
-                <IconButton aria-label="Light Mode">
-                    <DarkThemeIcon />
-                </IconButton>
-            </Tooltip >
-            :
-            <Tooltip title="Dark Mode" className={classes.darkThemeMobileButton} onClick={handleLightThemeToggle} >
-                <IconButton aria-label="Dark Mode">
-                    <LightThemeIcon />
-                </IconButton>
-            </Tooltip>
-        :
-            darkMode ?
-                <Tooltip title="Light Mode" className={classes.darkThemeButton} onClick={handleLightThemeToggle} >
-                    <IconButton aria-label="Light Mode">
-                        <DarkThemeIcon />
-                    </IconButton>
-                </Tooltip >
-                :
-                <Tooltip title="Dark Mode" className={classes.darkThemeButton} onClick={handleLightThemeToggle} >
-                    <IconButton aria-label="Dark Mode">
-                        <LightThemeIcon />
-                    </IconButton>
-                </Tooltip>
-    )
+  return (
+    <Tooltip
+      title={`${darkMode ? 'Dark' : "Light"} Mode`}
+      className={mobile ? classes.darkThemeMobileButton : classes.darkThemeButton}
+      onClick={handleLightThemeToggle}
+    >
+      <IconButton aria-label={`${darkMode ? 'Dark' : "Light"} Mode`}>
+        {darkMode ? <LightThemeIcon /> : <DarkThemeIcon />}
+      </IconButton>
+    </Tooltip>
+  )
 }
 
-export default DarkThemeSwitcher;
+export default DarkThemeSwitcher

--- a/src/pages/components/NavDrawer/NavDrawer.jsx
+++ b/src/pages/components/NavDrawer/NavDrawer.jsx
@@ -173,6 +173,7 @@ const NavDrawer = ({ children, window }) => {
               variant="temporary"
               anchor={theme.direction === "rtl" ? "right" : "left"}
               open={mobileOpen}
+              onOpen={console.debug("mobile draw open")}
               onClose={handleDrawerToggle}
               classes={{
                 paper: classes.drawerPaper,

--- a/src/pages/components/NavDrawer/NavDrawer.jsx
+++ b/src/pages/components/NavDrawer/NavDrawer.jsx
@@ -1,198 +1,216 @@
-import React, { useContext } from 'react';
-import PropTypes from 'prop-types';
-import { AppBar, CssBaseline, Divider, Drawer, Hidden, IconButton, List, ListItem, ListItemIcon, Toolbar, Tooltip, Typography, SwipeableDrawer } from '@material-ui/core';
-import { ThemeProvider, createMuiTheme } from '@material-ui/core/styles';
-import { makeStyles, useTheme } from '@material-ui/core/styles';
-import AttachMoneyIcon from '@material-ui/icons/AttachMoney';
-import SearchIcon from '@material-ui/icons/Search';
-import HomeIcon from '@material-ui/icons/Home';
-import InfoIcon from '@material-ui/icons/Info';
-import PersonIcon from '@material-ui/icons/Person';
-import MenuIcon from '@material-ui/icons/Menu';
-
-import DarkThemeContext from '../DarkThemeContext/DarkThemeContext';
-import DarkThemeSwitcher from '../DarkThemeSwitcher/DarkThemeSwitcher';
+import React from "react"
+import PropTypes from "prop-types"
+import {
+  AppBar,
+  CssBaseline,
+  Divider,
+  Drawer,
+  Hidden,
+  IconButton,
+  List,
+  ListItem,
+  ListItemIcon,
+  Toolbar,
+  Typography,
+  SwipeableDrawer,
+} from "@material-ui/core"
+import { ThemeProvider, createMuiTheme } from "@material-ui/core/styles"
+import { makeStyles, useTheme } from "@material-ui/core/styles"
+import AttachMoneyIcon from "@material-ui/icons/AttachMoney"
+import SearchIcon from "@material-ui/icons/Search"
+import HomeIcon from "@material-ui/icons/Home"
+import InfoIcon from "@material-ui/icons/Info"
+import PersonIcon from "@material-ui/icons/Person"
+import MenuIcon from "@material-ui/icons/Menu"
+import DarkThemeSwitcher from "../DarkThemeSwitcher/DarkThemeSwitcher"
+import useDarkThemeContext from "../DarkThemeContext/DarkThemeContext"
 import { Link } from "gatsby"
 
-const drawerWidth = 240;
+const drawerWidth = 240
 
-const useStyles = makeStyles((theme) => ({
-    root: {
-        display: 'flex',
+const useStyles = makeStyles(theme => ({
+  root: {
+    display: "flex",
+  },
+  drawer: {
+    [theme.breakpoints.up("sm")]: {
+      width: drawerWidth,
+      flexShrink: 0,
     },
-    drawer: {
-        [theme.breakpoints.up('sm')]: {
-            width: drawerWidth,
-            flexShrink: 0,
-        },
+  },
+  appBar: {
+    [theme.breakpoints.up("sm")]: {
+      width: `calc(100% - ${drawerWidth}px)`,
+      marginLeft: drawerWidth,
     },
-    appBar: {
-        [theme.breakpoints.up('sm')]: {
-            width: `calc(100% - ${drawerWidth}px)`,
-            marginLeft: drawerWidth,
-        },
+  },
+  menuButton: {
+    marginRight: theme.spacing(2),
+    [theme.breakpoints.up("sm")]: {
+      display: "none",
     },
-    menuButton: {
-        marginRight: theme.spacing(2),
-        [theme.breakpoints.up('sm')]: {
-            display: 'none',
-        },
+  },
+  // necessary for content to be below app bar
+  toolbar: theme.mixins.toolbar,
+  drawerPaper: {
+    width: drawerWidth,
+  },
+  content: {
+    flexGrow: 1,
+    padding: theme.spacing(3),
+  },
+  darkModeButton: {
+    background: "none",
+    border: "none",
+  },
+  darkModeMobileButton: {
+    [theme.breakpoints.up("sm")]: {
+      display: "none",
     },
-    // necessary for content to be below app bar
-    toolbar: theme.mixins.toolbar,
-    drawerPaper: {
-        width: drawerWidth,
+    [theme.breakpoints.down("sm")]: {
+      background: "none",
+      border: "none",
+      display: "visible",
+      paddingLeft: theme.spacing(2),
+      minWidth: "25%",
     },
-    content: {
-        flexGrow: 1,
-        padding: theme.spacing(3),
-    },
-    darkModeButton: {
-        background: "none",
-        border: "none",
-    },
-    darkModeMobileButton: {
-        [theme.breakpoints.up('sm')]: {
-            display: "none",
-        },
-        [theme.breakpoints.down('sm')]: {
-            background: "none",
-            border: "none",
-            display: "visible",
-            paddingLeft: theme.spacing(2),
-            minWidth: '25%'
-
-        },
-    },
-    menuHeaderText: {
-        minWidth: '97%',
-    }
-}));
+  },
+  menuHeaderText: {
+    minWidth: "97%",
+  },
+}))
 
 const NavDrawer = ({ children, window }) => {
-    const classes = useStyles();
-    const theme = useTheme();
-    const [mobileOpen, setMobileOpen] = React.useState(false);
-    const [darkMode, setDarkMode] = React.useState(React.useContext(DarkThemeContext).darkMode ? true : false);
-    const value = { darkMode, setDarkMode };
+  const classes = useStyles()
+  const theme = useTheme()
+  const [mobileOpen, setMobileOpen] = React.useState(false)
+  const { darkMode, setDarkMode } = useDarkThemeContext()
 
-    console.log("darkMode useContext", React.useContext(DarkThemeContext).darkMode)
+  console.log({ darkMode })
 
-    const handleDrawerToggle = () => {
-        setMobileOpen(!mobileOpen);
-    };
+  const handleDrawerToggle = () => {
+    setMobileOpen(!mobileOpen)
+  }
 
-    const linkStyles = {
-        textDecoration: "none",
-        color: darkMode ? "white" : "black"
-    }
+  const linkStyles = {
+    textDecoration: "none",
+    color: darkMode ? "white" : "black",
+  }
 
-    const activeStyle = {
-        textDecoration: "none",
-        color: "red"
-    }
+  const activeStyle = {
+    textDecoration: "none",
+    color: "red",
+  }
 
-    const darkModeStyling = createMuiTheme(darkMode ? {
-        palette: {
-            type: "dark",
-        }
-    } :
-        {
-            palette: {
-                type: "light",
-            }
-        });
+  const darkModeStyling = createMuiTheme({
+    palette: {
+      type: darkMode ? "dark" : "light",
+    },
+  })
 
-    const drawer = (
-        <div>
-            <div className={classes.toolbar} />
-            <DarkThemeSwitcher mobile/>
-            <Divider />
-            <List>
-                {[{ text: 'Home', href: '/', icon: <HomeIcon /> }, { text: 'Leaderboards', href: '/top-players/', icon: <PersonIcon /> },
-                { text: 'Donate', href: '/donate/', icon: <AttachMoneyIcon /> }, { text: 'Server Info', href: '/server-info/', icon: <InfoIcon /> },
-                { text: 'Player Stats', href: '/player-stats/', icon: <SearchIcon /> }]
-                    .map((link, index) => (
-                        <ListItem key={link.text}>
-                            <ListItemIcon>{link.icon}</ListItemIcon>
-                            <Link to={link.href} activeStyle={activeStyle} style={linkStyles} state={{ darkMode: darkMode }}>{link.text}</Link>
-                        </ListItem>
-                    ))}
-            </List>
-            <Divider />
-        </div>
-    );
+  const drawer = (
+    <div>
+      <div className={classes.toolbar} />
+      <DarkThemeSwitcher mobile />
+      <Divider />
+      <List>
+        {[
+          { text: "Home", href: "/", icon: <HomeIcon /> },
+          { text: "Leaderboards", href: "/top-players/", icon: <PersonIcon /> },
+          { text: "Donate", href: "/donate/", icon: <AttachMoneyIcon /> },
+          { text: "Server Info", href: "/server-info/", icon: <InfoIcon /> },
+          {
+            text: "Player Stats",
+            href: "/player-stats/",
+            icon: <SearchIcon />,
+          },
+        ].map((link, index) => (
+          <ListItem key={link.text}>
+            <ListItemIcon>{link.icon}</ListItemIcon>
+            <Link
+              to={link.href}
+              activeStyle={activeStyle}
+              style={linkStyles}
+              state={{ darkMode: darkMode }}
+            >
+              {link.text}
+            </Link>
+          </ListItem>
+        ))}
+      </List>
+      <Divider />
+    </div>
+  )
 
-    const container = window !== undefined ? () => window().document.body : undefined;
+  const container =
+    window !== undefined ? () => window().document.body : undefined
 
-    return (
-        <DarkThemeContext.Provider value={value}>
-            <ThemeProvider theme={darkModeStyling}>
-                <div className={classes.root}>
-                    <CssBaseline />
-                    <AppBar position="fixed" className={classes.appBar}>
-                        <Toolbar>
-                            <IconButton
-                                color="inherit"
-                                aria-label="open drawer"
-                                edge="start"
-                                onClick={handleDrawerToggle}
-                                className={classes.menuButton}
-                            >
-                                <MenuIcon />
-                            </IconButton>
-                            <Typography className={classes.menuHeaderText} variant="h6" noWrap>
-                                Fall to your death
-                            </Typography>
-                            <DarkThemeSwitcher mobile={false}/>
-                        </Toolbar>
-                    </AppBar>
-                    <nav className={classes.drawer} aria-label="navigation links">
-                        <Hidden smUp implementation="css">
-                            <SwipeableDrawer
-                                container={container}
-                                variant="temporary"
-                                anchor={theme.direction === 'rtl' ? 'right' : 'left'}
-                                open={mobileOpen}
-                                onClose={handleDrawerToggle}
-                                classes={{
-                                    paper: classes.drawerPaper,
-                                }}
-                                ModalProps={{
-                                    keepMounted: true, // Better open performance on mobile.
-                                }}
-                            >
-                                {drawer}
-                            </SwipeableDrawer>
-                        </Hidden>
-                        <Hidden xsDown implementation="css">
-                            <Drawer
-                                classes={{
-                                    paper: classes.drawerPaper,
-                                }}
-                                variant="permanent"
-                                open
-                            >
-                                {drawer}
-                            </Drawer>
-                        </Hidden>
-                    </nav>
-                    <main className={classes.content}>
-                        <div className={classes.toolbar} />
-                        {children}
-                    </main>
-                </div>
-            </ThemeProvider>
-        </DarkThemeContext.Provider>
-    );
+  return (
+    <ThemeProvider theme={darkModeStyling}>
+      <div className={classes.root}>
+        <CssBaseline />
+        <AppBar position="fixed" className={classes.appBar}>
+          <Toolbar>
+            <IconButton
+              color="inherit"
+              aria-label="open drawer"
+              edge="start"
+              onClick={handleDrawerToggle}
+              className={classes.menuButton}
+            >
+              <MenuIcon />
+            </IconButton>
+            <Typography className={classes.menuHeaderText} variant="h6" noWrap>
+              Fall to your death
+            </Typography>
+            <DarkThemeSwitcher mobile={false} />
+          </Toolbar>
+        </AppBar>
+        <nav className={classes.drawer} aria-label="navigation links">
+          <Hidden smUp implementation="css">
+            <SwipeableDrawer
+              container={container}
+              variant="temporary"
+              anchor={theme.direction === "rtl" ? "right" : "left"}
+              open={mobileOpen}
+              onClose={handleDrawerToggle}
+              classes={{
+                paper: classes.drawerPaper,
+              }}
+              ModalProps={{
+                keepMounted: true, // Better open performance on mobile.
+              }}
+            >
+              {drawer}
+            </SwipeableDrawer>
+          </Hidden>
+          <Hidden xsDown implementation="css">
+            <Drawer
+              classes={{
+                paper: classes.drawerPaper,
+              }}
+              variant="permanent"
+              open
+            >
+              {drawer}
+            </Drawer>
+          </Hidden>
+        </nav>
+        <main className={classes.content}>
+          <div className={classes.toolbar} />
+          {children}
+        </main>
+      </div>
+    </ThemeProvider>
+  )
 }
 
 NavDrawer.propTypes = {
-    /**
-     * Injected by the documentation to work in an iframe.
-     * You won't need it on your project.
-     */
-    window: PropTypes.func,
-};
+  /**
+   * Injected by the documentation to work in an iframe.
+   * You won't need it on your project.
+   */
+  window: PropTypes.func,
+}
 
-export default NavDrawer;
+export default NavDrawer

--- a/src/pages/top-players.js
+++ b/src/pages/top-players.js
@@ -33,7 +33,6 @@ export default function TopPlayers() {
     const columns = ["Name", "Weekly Kills", "Weekly Hours", "Kills Per Time Ratio"];
     const options = {
         filterType: 'checkbox',
-        responsive: "responsive",
         selectableRows: "none",
         pagination: false,
         filter: false,


### PR DESCRIPTION
The problem here was that you were essentially creating a new version of the context in each `NavWrapper` element, which was called every time you moved to a new page. Even though `NavWrapper` is called near the root of the element, it's not wrapping the root, so it gets re-initialised every time. 

If you want to maintain state between different pages in Gatsby, you need to wrap the root element by using the `gatsby-browser` api. if you were wrapping a whole theme provider, you'd also need to replicate this in the `gatsby-node` api to make sure it wrapped correctly when doing SSR.

The bulk of the logic is covered in this article: https://www.gatsbyjs.com/blog/2019-01-31-using-react-context-api-with-gatsby/, although the syntax is slightly dated. You can go further with this as well and implement what they've done to store the dark mode state in local storage, which means it'll persist between refreshes, but that's extra leg work. It's worth thinking about how much of this is done in JS too, as even with the local storage solution, you'll probably get a flash of default styling because it will initially show the SSR content. To manage that, you need to inject JS at the head of the document, which is what the source of this (https://www.gatsbyjs.com/plugins/gatsby-plugin-dark-mode/) does, which is very handy to have.

In general, also think about how you can use ternaries in your code to simply some of the switch logic, and maybe extract your theme out into a separate file or component so that it can be more easily edited and wrapped at the root. You'll also see that in `DarkThemeContext` I never export the context itself, just a hook to access it. This is personal preference but I think it's neater. You could obviously export all of the variables if you wanted to, this just makes it clean to access.

![persistent-dark-mode](https://user-images.githubusercontent.com/20226981/122453841-92d4c000-cfa2-11eb-85d3-8324f0dc8aab.gif)
